### PR TITLE
[feat] #44 해시태그 입력 기능

### DIFF
--- a/src/components/Community/FieldsetCommunity/FiledsetCommunity.jsx
+++ b/src/components/Community/FieldsetCommunity/FiledsetCommunity.jsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useRef, useState } from 'react';
 import Button from '../Button/Button';
+import InputHashtag from '../InputHashtag/InputHashtag';
 import WriteSelect from '../WriteSelect/WriteSelect';
 import {
   liStyle,
@@ -19,12 +20,11 @@ export default function FieldsetCommunity() {
   const labelRef = useRef();
   const [post, setPostInfo] = useState({ title: '', content: '', hashtags: '' });
 
-  const handleResizeTextareaHeight = e => {
+  const handleResizeHeight = e => {
     textareaRef.current.style.height = '3rem';
     textareaRef.current.style.height = `${textareaRef.current.scrollHeight / 17 - 0.5}rem`;
     labelRef.current.style.lineHeight = '5rem';
     labelRef.current.style.lineHeight = `${textareaRef.current.scrollHeight / 12}rem`;
-
     setPostInfo({ ...post, content: e.target.value });
   };
 
@@ -60,11 +60,12 @@ export default function FieldsetCommunity() {
               <p css={textStyle}>내용</p>
             </label>
             <textarea
+              rows={1}
               css={textareaStyle}
               value={post.content}
               name="content"
               placeholder="글 내용을 적어주세요."
-              onChange={e => handleResizeTextareaHeight(e)}
+              onChange={e => handleResizeHeight(e)}
               ref={textareaRef}
               required></textarea>
           </li>
@@ -74,12 +75,7 @@ export default function FieldsetCommunity() {
             <label htmlFor="tags" css={labelStyle}>
               <p css={textStyle}>태그</p>
             </label>
-            <input
-              css={inputStyle}
-              value={post.hashtags}
-              name="tags"
-              placeholder="해시태그를 입력하세요."
-              onChange={e => setPostInfo({ ...post, hashtags: e.target.value })}></input>
+            <InputHashtag />
           </li>
           <hr css={hrStyle} />
         </ul>

--- a/src/components/Community/InputHashtag/InputHashtag.jsx
+++ b/src/components/Community/InputHashtag/InputHashtag.jsx
@@ -7,8 +7,8 @@ export default function InputHashtag() {
   const [tags, setTags] = useState([]);
 
   const addTag = () => {
-    const tag = newTag.replaceAll(' ', '');
-    if (!tags.includes(tag)) {
+    const tag = newTag.replace(/[{}[\]/?.,;:|)*~`!^\-_+<>@#$%&\\=('"\s]/g, '');
+    if (!tags.includes(tag) && tag.length) {
       setTags([...tags, tag]);
     }
     setNewTag('');
@@ -21,11 +21,13 @@ export default function InputHashtag() {
   };
 
   const onKeyPress = e => {
-    if (e.target.value.trim().length && e.key === 'Enter') {
+    if (e.key === 'Enter') {
       addTag();
       e.preventDefault();
     }
   };
+
+  const onChangeHandler = e => setNewTag(e.target.value.slice(0, 10));
 
   return (
     <div css={tagDivStyle}>
@@ -42,7 +44,7 @@ export default function InputHashtag() {
         value={newTag}
         name="tags"
         placeholder="해시태그를 입력하세요."
-        onChange={e => setNewTag(e.target.value)}
+        onChange={e => onChangeHandler(e)}
         onKeyPress={onKeyPress}></input>
     </div>
   );

--- a/src/components/Community/InputHashtag/InputHashtag.jsx
+++ b/src/components/Community/InputHashtag/InputHashtag.jsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource @emotion/react */
+import { useState } from 'react';
+import { inputStyle, tagDivStyle, tagStyle, buttonStyle } from './InputHashtag.style';
+
+export default function InputHashtag() {
+  const [newTag, setNewTag] = useState('');
+  const [tags, setTags] = useState([]);
+
+  const addTag = () => {
+    const tag = newTag.replaceAll(' ', '');
+    if (!tags.includes(tag)) {
+      setTags([...tags, tag]);
+    }
+    setNewTag('');
+  };
+
+  const deleteTag = (e, index) => {
+    const newTags = tags.filter((_, tagIndex) => tagIndex !== index);
+    setTags(newTags);
+    e.preventDefault();
+  };
+
+  const onKeyPress = e => {
+    if (e.target.value.trim().length && e.key === 'Enter') {
+      addTag();
+      e.preventDefault();
+    }
+  };
+
+  return (
+    <div css={tagDivStyle}>
+      {tags.map((tag, index) => (
+        <div key={index} css={tagStyle}>
+          #{tag}
+          <button css={buttonStyle} onClick={e => deleteTag(e, index)}>
+            X
+          </button>
+        </div>
+      ))}
+      <input
+        css={inputStyle(tags.length)}
+        value={newTag}
+        name="tags"
+        placeholder="해시태그를 입력하세요."
+        onChange={e => setNewTag(e.target.value)}
+        onKeyPress={onKeyPress}></input>
+    </div>
+  );
+}

--- a/src/components/Community/InputHashtag/InputHashtag.style.jsx
+++ b/src/components/Community/InputHashtag/InputHashtag.style.jsx
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+
+const inputStyle = length => css`
+  font-weight: 500;
+  font-size: 12px;
+
+  border-style: none;
+
+  &::placeholder {
+    color: #adb1bd;
+  }
+
+  display: ${length > 2 ? 'none' : ''};
+`;
+
+const tagDivStyle = css`
+  display: flex;
+  width: content;
+  padding: 10px;
+
+  font-weight: 500;
+  font-size: 12px;
+
+  &::placeholder {
+    color: #adb1bd;
+  }
+
+  border: 1px solid #eaeaea;
+  border-radius: 6px;
+`;
+
+const tagStyle = css`
+  font-weight: 500;
+  font-size: 12px;
+
+  color: #5c8aff;
+`;
+
+const buttonStyle = css`
+  border-style: none;
+
+  color: #ff6b7d;
+  background-color: white;
+
+  font-weight: 500;
+  font-size: 12px;
+
+  cursor: pointer;
+`;
+
+export { inputStyle, tagDivStyle, tagStyle, buttonStyle };

--- a/src/components/Community/WriteSelect/WriteSelect.jsx
+++ b/src/components/Community/WriteSelect/WriteSelect.jsx
@@ -14,7 +14,7 @@ export default function WriteSelect() {
   return (
     <select css={selectStyle} required name="category" value={selected} onChange={handleSelect}>
       {selectList.map(item => (
-        <option value={item} key={item} disabled={item === defaultOption}>
+        <option key={item} value={item} disabled={item === defaultOption}>
           {item}
         </option>
       ))}

--- a/src/components/Community/WriteSelect/WriteSelect.style.jsx
+++ b/src/components/Community/WriteSelect/WriteSelect.style.jsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-const selectStyle = css`
+export default css`
   height: 2rem;
   width: 20%;
   border: 1px solid #eaeaea;
@@ -10,5 +10,3 @@ const selectStyle = css`
     display: none;
   }
 `;
-
-export default { selectStyle };


### PR DESCRIPTION
1. 무슨 이유로 코드를 변경했나요?
- 글에 해시태그를 추가할 수 있습니다.
<br><br>
2. 어떤 위험이나 장애를 발견했나요?
X
<br><br>
3. 관련 스크린샷을 첨부해주세요.
- 해시 태그는 4가지 기능을 갖고 있습니다.
<br><br>

> 해시태그를 입력하고 엔터 입력 시 해시태그가 추가됩니다.
![image](https://user-images.githubusercontent.com/86355699/217734783-d15ec822-7e98-4f01-953a-118176f12964.png)
- 이 경우 단어에 존재하는 공백(`' '`)은 모두 사라진 형태로 입력됩니다.
<br><br>

> 해시태그 옆에 존재하는 `X` 버튼을 클릭하는 경우 해시태그는 삭제됩니다.
![image](https://user-images.githubusercontent.com/86355699/217736033-4f4e1e77-badc-4b4c-ac64-c48bb3b24e5d.png)
- `X` 버튼은 `cursor: pointer` 스타일이 추가되어 있습니다.  
<br>

> 마지막으로 해시태그는 3개까지만 입력할 수 있습니다. 
> 따라서 3개의 해시태그가 입력된 경우 `input` 태그가 사라져 더 입력할 수 없습니다.  
![image](https://user-images.githubusercontent.com/86355699/217735923-1e765101-69a0-4d94-ab2b-0ceba58f9fe1.png)
- 해시태그 개수에 따라 `display` 속성을 변경하였습니다.

<br>

4. 완료 사항
- 모든 구현을 완료하였습니다.
<br>

5. 리뷰어에게 남기는 말
- 해시태그의 길이, 사용 가능한 문자(특수문자)에 대한 의견을 주시면 감사하겠습니다.

close #38 
close #29 